### PR TITLE
Retry Gemini tailoring when output is unchanged

### DIFF
--- a/backend/src/services/gemini.py
+++ b/backend/src/services/gemini.py
@@ -119,6 +119,27 @@ class GeminiService:
             logger.error(f"Gemini request failed after {settings.GEMINI_RETRY_ATTEMPTS} attempts")
             return None
 
+    def _build_tailoring_prompt(
+        self,
+        resume_json: str,
+        job_description: str,
+        force_changes: bool = False,
+    ) -> str:
+        """Build tailoring prompt with optional strict change requirements."""
+        prompt = get_tailoring_prompt(resume_json, job_description)
+        if force_changes:
+            prompt += """
+
+STRICT REQUIREMENTS:
+- You MUST make visible improvements to the resume text.
+- Rewrite the professional summary.
+- Update at least 2 bullet points in work experience.
+- Reorder skills by relevance to the job description.
+- Do NOT return the original resume unchanged.
+"""
+
+        return add_json_enforcement(prompt)
+
     def _parse_json_response(self, response_text: str) -> Optional[Dict[str, Any]]:
         """
         Parse JSON response from Gemini, handling various formats
@@ -284,7 +305,7 @@ class GeminiService:
         logger.debug(f"Resume JSON preview: {resume_json[:500]}...")
 
         # Generate prompt
-        prompt = add_json_enforcement(get_tailoring_prompt(resume_json, job_description))
+        prompt = self._build_tailoring_prompt(resume_json, job_description)
         logger.debug("🔍 RESUME TAILORING - Generated prompt:")
         logger.debug(f"Prompt length: {len(prompt)} characters")
 
@@ -344,6 +365,28 @@ class GeminiService:
 
             # Parse tailored resume
             tailored_resume = Resume(**tailored_resume_data)
+
+            # Retry once if the resume is unchanged from the original
+            if self._is_resume_unchanged(resume, tailored_resume):
+                logger.warning(
+                    "⚠️ Tailored resume matches original; retrying with strict change requirements."
+                )
+                retry_prompt = self._build_tailoring_prompt(
+                    resume_json,
+                    job_description,
+                    force_changes=True,
+                )
+                retry_response = self._make_request(retry_prompt)
+                if retry_response:
+                    retry_parsed = self._parse_json_response(retry_response)
+                    retry_data = retry_parsed.get("tailoredResume") if retry_parsed else None
+                    if retry_data:
+                        retry_data = self._merge_with_original(resume, retry_data)
+                        retry_resume = Resume(**retry_data)
+                        if not self._is_resume_unchanged(resume, retry_resume):
+                            tailored_resume = retry_resume
+                            tailored_resume_data = retry_data
+                            parsed_response = retry_parsed
 
             # Determine matched keywords (fallback if missing)
             matched_keywords = parsed_response.get("matchedKeywords", [])
@@ -465,6 +508,12 @@ class GeminiService:
         # Return capitalized form based on original skills order
         ordered = [skill for skill in resume.skills if skill.lower() in matched]
         return ordered
+
+    def _is_resume_unchanged(self, original: Resume, tailored: Resume) -> bool:
+        """Check if tailored resume is identical to the original."""
+        original_data = original.model_dump(mode="json", exclude_none=False)
+        tailored_data = tailored.model_dump(mode="json", exclude_none=False)
+        return original_data == tailored_data
 
     def _merge_with_original(self, original: Resume, ai_data: Dict[str, Any]) -> Dict[str, Any]:
         """Merge AI output with original resume to ensure required fields are present.


### PR DESCRIPTION
### Motivation
- Users observed that the tailored output was identical to the original resume (no changes applied).
- Root cause: Gemini responses sometimes return the original resume unchanged because prompts did not force visible edits and there was no detection/retry logic.
- Goal: ensure the service detects no-op AI outputs and re-requests a stricter tailoring pass so the resume is meaningfully updated.

### Description
- Added `_build_tailoring_prompt` to construct the tailoring prompt and a `force_changes` path that enforces visible edits and explicit requirements.
- Implemented `_is_resume_unchanged` to compare original vs. AI-tailored resumes using `model_dump` and detect no-op responses.
- Updated `tailor_resume` to retry once with the strict prompt when the first AI response yields an unchanged resume and to merge/replace the parsed response on success.
- Added unit test `test_tailor_endpoint_retries_when_unchanged` to verify retry behavior and updated test configuration in `backend/tests/test_tailor.py`.

### Testing
- Ran `pytest backend/tests/test_tailor.py -k "unchanged"` which exercised the new retry flow and the test passed.
- The new test asserts the second Gemini response is used when the first returns an unchanged resume and verifies `generate_content` was called twice.
- Existing tailoring unit tests remain in place and were not modified aside from adding this new case.
- No automated tests failed during these runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f3c2768e883308cec151ecaf2aa50)