### PR TITLE
Add Open Resume PDF settings via env and pass to Open-Resume

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,6 +12,10 @@ CORS_ORIGINS=chrome-extension://*,http://localhost:5173,http://localhost:3000
 # Open Resume Service Configuration
 OPEN_RESUME_URL=http://localhost:3000
 OPEN_RESUME_API_TIMEOUT=30
+OPEN_RESUME_FONT_FAMILY=Open Sans
+OPEN_RESUME_FONT_SIZE=11
+OPEN_RESUME_THEME_COLOR=#000000
+OPEN_RESUME_DOCUMENT_SIZE=A4
 
 # Google Gemini AI Configuration (REQUIRED)
 # Get your API key from: https://aistudio.google.com/app/apikey

--- a/backend/src/app/config.py
+++ b/backend/src/app/config.py
@@ -40,6 +40,10 @@ class Settings(BaseSettings):
     # Open Resume Service Configuration
     OPEN_RESUME_URL: str = "http://localhost:3001"
     OPEN_RESUME_API_TIMEOUT: int = 30
+    OPEN_RESUME_FONT_FAMILY: str = "Open Sans"
+    OPEN_RESUME_FONT_SIZE: int = 11
+    OPEN_RESUME_THEME_COLOR: str = ""
+    OPEN_RESUME_DOCUMENT_SIZE: str = "A4"
 
     # Gemini AI Configuration (NEW google-genai package)
     GEMINI_API_KEY: str = ""

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -180,6 +180,10 @@ def env_setup(monkeypatch):
     monkeypatch.setenv("ENVIRONMENT", "testing")
     monkeypatch.setenv("GEMINI_API_KEY", "test-key-12345678901234567890123456789012")
     monkeypatch.setenv("OPEN_RESUME_URL", "http://localhost:3000")
+    monkeypatch.setenv("OPEN_RESUME_FONT_FAMILY", "Open Sans")
+    monkeypatch.setenv("OPEN_RESUME_FONT_SIZE", "11")
+    monkeypatch.setenv("OPEN_RESUME_THEME_COLOR", "#000000")
+    monkeypatch.setenv("OPEN_RESUME_DOCUMENT_SIZE", "A4")
     monkeypatch.setenv("LOG_LEVEL", "ERROR")  # Reduce logging in tests
 
 

--- a/backend/tests/test_pdf_client_settings.py
+++ b/backend/tests/test_pdf_client_settings.py
@@ -1,0 +1,24 @@
+"""
+Tests for Open Resume PDF client settings mapping.
+"""
+
+from app.config import settings
+from services.pdf_client import PDFClientService
+
+
+def test_pdf_payload_includes_open_resume_settings(sample_resume):
+    settings.OPEN_RESUME_FONT_FAMILY = "Roboto"
+    settings.OPEN_RESUME_FONT_SIZE = 10
+    settings.OPEN_RESUME_THEME_COLOR = "#112233"
+    settings.OPEN_RESUME_DOCUMENT_SIZE = "LEGAL"
+
+    client = PDFClientService()
+    payload = client._to_open_resume_payload(sample_resume)
+
+    assert payload["settings"] == {
+        "fontFamily": "Roboto",
+        "fontSize": 10,
+        "themeColor": "#112233",
+        "documentSize": "LEGAL",
+    }
+    assert payload["resume"]["profile"]["name"] == sample_resume.personalInfo.name

--- a/open-resume-service/src/app/api/generate-pdf/route.ts
+++ b/open-resume-service/src/app/api/generate-pdf/route.ts
@@ -8,7 +8,7 @@ export async function POST(request: NextRequest) {
   try {
     // Parse request body
     const body = await request.json();
-    const { resume, template = "default" } = body;
+    const { resume, template = "default", settings } = body;
 
     if (!resume) {
       return NextResponse.json(
@@ -22,7 +22,7 @@ export async function POST(request: NextRequest) {
     const { generatePDF } = await import("../../../lib/resume-pdf-generator");
 
     // Generate PDF
-    const pdfBuffer = await generatePDF(resume, template);
+    const pdfBuffer = await generatePDF(resume, template, settings);
 
     // Return PDF as binary response
     return new NextResponse(pdfBuffer, {


### PR DESCRIPTION
### Motivation
- Make PDF output follow Open-Resume template options by exposing style/document settings (font family, font size, theme color, document size) via environment variables. 
- Ensure those settings are forwarded to the Open-Resume generator so PDFs use configured fonts, sizes, color, and document type. 
- Normalize the payload shape expected by Open-Resume by nesting resume data under `resume` and including a top-level `settings` block. 
- Add a focused unit test to prevent regressions in the settings mapping.

### Description
- Added new settings to the backend config `Settings` class: `OPEN_RESUME_FONT_FAMILY`, `OPEN_RESUME_FONT_SIZE`, `OPEN_RESUME_THEME_COLOR`, and `OPEN_RESUME_DOCUMENT_SIZE` and updated `backend/.env.example` accordingly. 
- Updated the PDF payload mapping in `backend/src/services/pdf_client.py` to produce `{ "resume": { ... }, "settings": { ... } }`, and implemented helper formatting functions used when building the payload. 
- Modified the Open-Resume API endpoint `open-resume-service/src/app/api/generate-pdf/route.ts` to accept an optional `settings` field and pass it into `generatePDF`. 
- Added `backend/tests/test_pdf_client_settings.py` and updated `backend/tests/conftest.py` to provide env defaults and validate the settings mapping produced by `_to_open_resume_payload`.

### Testing
- Ran `pytest backend/tests/test_pdf_client_settings.py` which executed the new mapping test and it passed. 
- The test run produced standard warnings (Pydantic/FastAPI deprecation warnings) but no failures. 
- Coverage output was generated as part of the test run (local coverage summary reported). 
- No other automated tests were modified or executed in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960240a98148330a326f5c018fa553d)