### PR TITLE
Add Open-Resume PDF generator, constants, and settings (support LEGAL size)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,7 @@ backend/src/__pycache__/
 backend/tests/__pycache__/
 *.pdf
 *.docx
+
+# Allow Open Resume app library files
+!open-resume-service/src/app/lib/
+!open-resume-service/src/app/lib/**

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,6 +12,10 @@ CORS_ORIGINS=chrome-extension://*,http://localhost:5173,http://localhost:3000
 # Open Resume Service Configuration
 OPEN_RESUME_URL=http://localhost:3000
 OPEN_RESUME_API_TIMEOUT=30
+OPEN_RESUME_FONT_FAMILY=Open Sans
+OPEN_RESUME_FONT_SIZE=11
+OPEN_RESUME_THEME_COLOR=#000000
+OPEN_RESUME_DOCUMENT_SIZE=A4
 
 # Google Gemini AI Configuration (REQUIRED)
 # Get your API key from: https://aistudio.google.com/app/apikey

--- a/backend/src/app/config.py
+++ b/backend/src/app/config.py
@@ -40,6 +40,10 @@ class Settings(BaseSettings):
     # Open Resume Service Configuration
     OPEN_RESUME_URL: str = "http://localhost:3001"
     OPEN_RESUME_API_TIMEOUT: int = 30
+    OPEN_RESUME_FONT_FAMILY: str = "Open Sans"
+    OPEN_RESUME_FONT_SIZE: int = 11
+    OPEN_RESUME_THEME_COLOR: str = ""
+    OPEN_RESUME_DOCUMENT_SIZE: str = "A4"
 
     # Gemini AI Configuration (NEW google-genai package)
     GEMINI_API_KEY: str = ""

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -180,6 +180,10 @@ def env_setup(monkeypatch):
     monkeypatch.setenv("ENVIRONMENT", "testing")
     monkeypatch.setenv("GEMINI_API_KEY", "test-key-12345678901234567890123456789012")
     monkeypatch.setenv("OPEN_RESUME_URL", "http://localhost:3000")
+    monkeypatch.setenv("OPEN_RESUME_FONT_FAMILY", "Open Sans")
+    monkeypatch.setenv("OPEN_RESUME_FONT_SIZE", "11")
+    monkeypatch.setenv("OPEN_RESUME_THEME_COLOR", "#000000")
+    monkeypatch.setenv("OPEN_RESUME_DOCUMENT_SIZE", "A4")
     monkeypatch.setenv("LOG_LEVEL", "ERROR")  # Reduce logging in tests
 
 

--- a/backend/tests/test_pdf_client_settings.py
+++ b/backend/tests/test_pdf_client_settings.py
@@ -1,0 +1,24 @@
+"""
+Tests for Open Resume PDF client settings mapping.
+"""
+
+from app.config import settings
+from services.pdf_client import PDFClientService
+
+
+def test_pdf_payload_includes_open_resume_settings(sample_resume):
+    settings.OPEN_RESUME_FONT_FAMILY = "Roboto"
+    settings.OPEN_RESUME_FONT_SIZE = 10
+    settings.OPEN_RESUME_THEME_COLOR = "#112233"
+    settings.OPEN_RESUME_DOCUMENT_SIZE = "LEGAL"
+
+    client = PDFClientService()
+    payload = client._to_open_resume_payload(sample_resume)
+
+    assert payload["settings"] == {
+        "fontFamily": "Roboto",
+        "fontSize": 10,
+        "themeColor": "#112233",
+        "documentSize": "LEGAL",
+    }
+    assert payload["resume"]["profile"]["name"] == sample_resume.personalInfo.name

--- a/open-resume-service/src/app/api/generate-pdf/route.ts
+++ b/open-resume-service/src/app/api/generate-pdf/route.ts
@@ -8,7 +8,7 @@ export async function POST(request: NextRequest) {
   try {
     // Parse request body
     const body = await request.json();
-    const { resume, template = "default" } = body;
+    const { resume, template = "default", settings } = body;
 
     if (!resume) {
       return NextResponse.json(
@@ -22,7 +22,7 @@ export async function POST(request: NextRequest) {
     const { generatePDF } = await import("../../../lib/resume-pdf-generator");
 
     // Generate PDF
-    const pdfBuffer = await generatePDF(resume, template);
+    const pdfBuffer = await generatePDF(resume, template, settings);
 
     // Return PDF as binary response
     return new NextResponse(pdfBuffer, {

--- a/open-resume-service/src/app/components/Resume/ResumePDF/index.tsx
+++ b/open-resume-service/src/app/components/Resume/ResumePDF/index.tsx
@@ -97,7 +97,13 @@ export const ResumePDF = ({
     <>
       <Document title={`${name} Resume`} author={name} producer={"OpenResume"}>
         <Page
-          size={documentSize === "A4" ? "A4" : "LETTER"}
+          size={
+            documentSize === "A4"
+              ? "A4"
+              : documentSize === "LEGAL"
+                ? "LEGAL"
+                : "LETTER"
+          }
           style={{
             ...styles.flexCol,
             color: DEFAULT_FONT_COLOR,

--- a/open-resume-service/src/app/lib/constants.ts
+++ b/open-resume-service/src/app/lib/constants.ts
@@ -1,0 +1,7 @@
+export const DEBUG_RESUME_PDF_FLAG = false;
+
+export const PX_PER_PT = 1.3333;
+export const A4_WIDTH_PX = 794;
+export const A4_HEIGHT_PX = 1123;
+export const LETTER_WIDTH_PX = 816;
+export const LETTER_HEIGHT_PX = 1056;

--- a/open-resume-service/src/app/lib/redux/settingsSlice.ts
+++ b/open-resume-service/src/app/lib/redux/settingsSlice.ts
@@ -1,0 +1,58 @@
+export const DEFAULT_FONT_COLOR = "#000000";
+
+export type ShowForm =
+  | "workExperiences"
+  | "educations"
+  | "projects"
+  | "skills"
+  | "custom";
+
+export type GeneralSetting = "fontFamily" | "fontSize" | "documentSize" | "themeColor";
+
+export type Settings = {
+  fontFamily: string;
+  fontSize: number;
+  documentSize: "A4" | "LETTER" | "LEGAL";
+  themeColor?: string;
+  formToHeading: Record<ShowForm, string>;
+  formToShow: Record<ShowForm, boolean>;
+  formsOrder: ShowForm[];
+  showBulletPoints: Record<ShowForm, boolean>;
+};
+
+export const initialSettings: Settings = {
+  fontFamily: "Open Sans",
+  fontSize: 11,
+  documentSize: "A4",
+  themeColor: "",
+  formToHeading: {
+    workExperiences: "WORK EXPERIENCE",
+    educations: "EDUCATION",
+    projects: "PROJECTS",
+    skills: "SKILLS",
+    custom: "CUSTOM",
+  },
+  formToShow: {
+    workExperiences: true,
+    educations: true,
+    projects: true,
+    skills: true,
+    custom: true,
+  },
+  formsOrder: ["workExperiences", "educations", "projects", "skills", "custom"],
+  showBulletPoints: {
+    workExperiences: true,
+    educations: true,
+    projects: true,
+    skills: true,
+    custom: true,
+  },
+};
+
+export const selectSettings = (state: { settings: Settings }) => state.settings;
+export const selectFormsOrder = (state: { settings: Settings }) => state.settings.formsOrder;
+export const selectShowForm = (state: { settings: Settings }, form: ShowForm) =>
+  state.settings.formToShow[form];
+
+export const changeSettings = () => ({ type: "settings/changeSettings" });
+export const changeShowForm = () => ({ type: "settings/changeShowForm" });

--- a/open-resume-service/src/app/lib/redux/types.ts
+++ b/open-resume-service/src/app/lib/redux/types.ts
@@ -1,0 +1,50 @@
+export type ResumeProfile = {
+  name: string;
+  summary?: string;
+  email?: string;
+  phone?: string;
+  location?: string;
+  url?: string;
+  portfolio?: string;
+  github?: string;
+};
+
+export type ResumeWorkExperience = {
+  company: string;
+  jobTitle: string;
+  date?: string;
+  descriptions: string[];
+};
+
+export type ResumeEducation = {
+  school: string;
+  degree: string;
+  date?: string;
+  gpa?: string;
+  descriptions?: string[];
+};
+
+export type ResumeProject = {
+  project: string;
+  date?: string;
+  descriptions: string[];
+  url?: string;
+};
+
+export type ResumeSkills = {
+  featuredSkills: { skill: string; rating: number }[];
+  descriptions: string[];
+};
+
+export type ResumeCustom = {
+  descriptions: string[];
+};
+
+export type Resume = {
+  profile: ResumeProfile;
+  workExperiences: ResumeWorkExperience[];
+  educations: ResumeEducation[];
+  projects: ResumeProject[];
+  skills: ResumeSkills;
+  custom: ResumeCustom;
+};

--- a/open-resume-service/src/app/lib/resume-pdf-generator.test.ts
+++ b/open-resume-service/src/app/lib/resume-pdf-generator.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment node
+ */
+import { generatePDF } from "lib/resume-pdf-generator";
+import type { Resume } from "lib/redux/types";
+
+const sampleResume: Resume = {
+  profile: {
+    name: "Jane Doe",
+    email: "jane@example.com",
+    phone: "555-0101",
+    location: "Remote",
+    url: "linkedin.com/in/janedoe",
+    portfolio: "janedoe.dev",
+    github: "github.com/janedoe",
+    summary: "Backend engineer focused on scalable services.",
+  },
+  workExperiences: [
+    {
+      company: "Acme",
+      jobTitle: "Senior Engineer",
+      date: "2021 - Present",
+      descriptions: ["Built APIs used by 1M users."],
+    },
+  ],
+  educations: [
+    {
+      school: "State University",
+      degree: "B.S. Computer Science",
+      date: "2016 - 2020",
+      gpa: "3.8",
+      descriptions: ["Graduated with honors."],
+    },
+  ],
+  projects: [
+    {
+      project: "Resume Builder",
+      date: "2023",
+      descriptions: ["Implemented PDF rendering pipeline."],
+      url: "https://github.com/janedoe/resume-builder",
+    },
+  ],
+  skills: {
+    featuredSkills: [{ skill: "Python", rating: 4 }],
+    descriptions: ["Python, FastAPI, Postgres"],
+  },
+  custom: {
+    descriptions: [],
+  },
+};
+
+describe("generatePDF", () => {
+  it("renders a PDF buffer with settings overrides", async () => {
+    const pdfBuffer = await generatePDF(sampleResume, "default", {
+      fontFamily: "Open Sans",
+      fontSize: 10,
+      documentSize: "LEGAL",
+      themeColor: "#111111",
+    });
+
+    expect(pdfBuffer).toBeInstanceOf(Buffer);
+    expect(pdfBuffer.length).toBeGreaterThan(0);
+  });
+});

--- a/open-resume-service/src/app/lib/resume-pdf-generator.tsx
+++ b/open-resume-service/src/app/lib/resume-pdf-generator.tsx
@@ -1,0 +1,60 @@
+import path from "path";
+import { renderToBuffer, Font } from "@react-pdf/renderer";
+import { ResumePDF } from "components/Resume/ResumePDF";
+import { initialSettings, type Settings } from "lib/redux/settingsSlice";
+import type { Resume } from "lib/redux/types";
+
+type GeneratePDFSettings = Partial<Settings>;
+
+const FONT_FILES: Record<string, { regular: string; bold: string }> = {
+  "Open Sans": {
+    regular: "OpenSans-Regular.ttf",
+    bold: "OpenSans-Bold.ttf",
+  },
+  Roboto: {
+    regular: "Roboto-Regular.ttf",
+    bold: "Roboto-Bold.ttf",
+  },
+  Lato: {
+    regular: "Lato-Regular.ttf",
+    bold: "Lato-Bold.ttf",
+  },
+};
+
+const registerFontFamily = (fontFamily: string) => {
+  const files = FONT_FILES[fontFamily];
+  if (!files) {
+    return;
+  }
+  const fontsDir = path.join(process.cwd(), "public", "fonts");
+  Font.register({
+    family: fontFamily,
+    fonts: [
+      { src: path.join(fontsDir, files.regular), fontWeight: "normal" },
+      { src: path.join(fontsDir, files.bold), fontWeight: "bold" },
+    ],
+  });
+};
+
+const buildSettings = (settings?: GeneratePDFSettings): Settings => ({
+  ...initialSettings,
+  ...settings,
+});
+
+export const generatePDF = async (
+  resume: Resume,
+  template = "default",
+  settings?: GeneratePDFSettings
+) => {
+  if (template !== "default") {
+    throw new Error(`Unsupported template: ${template}`);
+  }
+
+  const mergedSettings = buildSettings(settings);
+  registerFontFamily(mergedSettings.fontFamily);
+  const document = (
+    <ResumePDF resume={resume} settings={mergedSettings} isPDF={true} />
+  );
+
+  return renderToBuffer(document);
+};


### PR DESCRIPTION
### Motivation
- Provide a self-contained PDF generation module for the Open Resume service so the backend can produce PDFs using the same template logic and fonts as the web UI. 
- Surface and forward template settings (font family, font size, theme color, document size) so generated PDFs match user-configured UI settings. 
- Fix a failing generator test caused by a missing library layer and incorrect renderer usage. 
- Ensure the new Open Resume library files are tracked so CI and local runs include the PDF generator.

### Description
- Added `open-resume-service/src/app/lib/resume-pdf-generator.tsx` implementing `generatePDF` with font registration and using `renderToBuffer` from `@react-pdf/renderer`.
- Introduced types and defaults via `open-resume-service/src/app/lib/redux/types.ts` and `open-resume-service/src/app/lib/redux/settingsSlice.ts`, and rendering constants in `open-resume-service/src/app/lib/constants.ts`.
- Updated the PDF template renderer to support `LEGAL` page size in `ResumePDF` and wired `settings` through the API route to the generator.
- Added `open-resume-service/src/app/lib/resume-pdf-generator.test.ts` and updated `.gitignore` to allow committing the new `lib/` files.

### Testing
- Ran `npm test -- --runTestsByPath src/app/lib/resume-pdf-generator.test.ts` which initially failed due to using `pdf(...).toBuffer()`, and after switching to `renderToBuffer` the test passed. 
- The Jest test verifies `generatePDF` returns a non-empty `Buffer` when provided `settings` overrides and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960240a98148330a326f5c018fa553d)